### PR TITLE
Bump build number with 1 and rebuild with rattler-build 0.39.0

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 846a59ca86bcd014322267995ba307cd6a197081f4b75d085596d723dd8a633e
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
The latest build of mdbook fails with `zsh: Killed` on `osx-arm64` (at least on my machine), see https://github.com/conda-forge/rattler-build-feedstock/issues/149 for more context. Rebuilding with the latest rattler-build (as done in this PR) should fix the problem.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
